### PR TITLE
#154240253 Bug: Exercise cache when deleting muscles

### DIFF
--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -76,6 +76,25 @@ class Muscle(models.Model):
         '''
         return False
 
+    def delete(self, *args, **kwargs):
+        '''
+        Reset all cached info
+        '''
+        for language in Language.objects.all():
+            delete_template_fragment_cache('muscle-overview', language.id)
+            delete_template_fragment_cache('equipment-overview', language.id)
+            delete_template_fragment_cache('exercise-overview', language.id)
+            delete_template_fragment_cache('exercise-overview-mobile', language.id)
+        exercise_container = Exercise.objects.filter(muscles=self).iterator()
+
+        # Handle cached template scraps
+        for exercise in exercise_container:
+            # Handle cached exercise objects
+            cache.delete(cache_mapper.get_exercise_muscle_bg_key(exercise.pk))
+            for set in exercise.set_set.all():
+                reset_workout_canonical_form(set.exerciseday.training.pk)
+        super(Muscle, self).delete(*args, **kwargs)
+
 
 @python_2_unicode_compatible
 class Equipment(models.Model):
@@ -104,25 +123,6 @@ class Equipment(models.Model):
         Equipment has no owner information
         '''
         return False
-
-    def delete(self, *args, **kwargs):
-        '''
-        Reset all cached info
-        '''
-        for language in Language.objects.all():
-            delete_template_fragment_cache('muscle-overview', language.id)
-            delete_template_fragment_cache('equipment-overview', language.id)
-            delete_template_fragment_cache('exercise-overview', language.id)
-            delete_template_fragment_cache('exercise-overview-mobile', language.id)
-        exercise_container = Exercise.objects.filter(muscles=self).iterator()
-
-        # Handle cached template scraps
-        for exercise in exercise_container:
-            # Handle cached exercise objects
-            cache.delete(cache_mapper.get_exercise_muscle_bg_key(exercise.pk))
-            for set in exercise.set_set.all():
-                reset_workout_canonical_form(set.exerciseday.training.pk)
-        super(Muscle, self).delete(*args, **kwargs)
 
 
 @python_2_unicode_compatible

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -105,6 +105,25 @@ class Equipment(models.Model):
         '''
         return False
 
+    def delete(self, *args, **kwargs):
+        '''
+        Reset all cached info
+        '''
+        for language in Language.objects.all():
+            delete_template_fragment_cache('muscle-overview', language.id)
+            delete_template_fragment_cache('equipment-overview', language.id)
+            delete_template_fragment_cache('exercise-overview', language.id)
+            delete_template_fragment_cache('exercise-overview-mobile', language.id)
+        exercise_container = Exercise.objects.filter(muscles=self).iterator()
+
+        # Handle cached template scraps
+        for exercise in exercise_container:
+            # Handle cached exercise objects
+            cache.delete(cache_mapper.get_exercise_muscle_bg_key(exercise.pk))
+            for set in exercise.set_set.all():
+                reset_workout_canonical_form(set.exerciseday.training.pk)
+        super(Muscle, self).delete(*args, **kwargs)
+
 
 @python_2_unicode_compatible
 class ExerciseCategory(models.Model):

--- a/wger/exercises/signals.py
+++ b/wger/exercises/signals.py
@@ -19,7 +19,6 @@ from django.dispatch import receiver
 from easy_thumbnails.files import get_thumbnailer
 from easy_thumbnails.signal_handlers import generate_aliases
 from easy_thumbnails.signals import saved_file
-
 from wger.exercises.models import ExerciseImage
 from django.core.cache import cache
 from wger.exercises.models import (Muscle)
@@ -28,6 +27,7 @@ from wger.exercises.models import (Muscle)
 @receiver([post_delete, pre_save], sender=Muscle)
 def delete_exercise_on_delete(sender, instance, **kwargs):
     cache.clear()
+
 
 @receiver(post_delete, sender=ExerciseImage)
 def delete_exercise_image_on_delete(sender, instance, **kwargs):

--- a/wger/exercises/signals.py
+++ b/wger/exercises/signals.py
@@ -14,15 +14,20 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 
-from django.db.models.signals import pre_save
-from django.db.models.signals import post_delete
+from django.db.models.signals import pre_save, post_delete
 from django.dispatch import receiver
 from easy_thumbnails.files import get_thumbnailer
 from easy_thumbnails.signal_handlers import generate_aliases
 from easy_thumbnails.signals import saved_file
 
 from wger.exercises.models import ExerciseImage
+from django.core.cache import cache
+from wger.exercises.models import (Muscle)
 
+
+@receiver([post_delete, pre_save], sender=Muscle)
+def delete_exercise_on_delete(sender, instance, **kwargs):
+    cache.clear()
 
 @receiver(post_delete, sender=ExerciseImage)
 def delete_exercise_image_on_delete(sender, instance, **kwargs):

--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -39,6 +39,11 @@ class MuscleListView(ListView):
     context_object_name = 'muscle_list'
     template_name = 'muscles/overview.html'
 
+    def get_queryset(self):
+        if self.template_name == "muscles/overview.html":
+            return Muscle.objects.all().order_by('-is_front', 'name'),
+        return Muscle.objects.all().order_by('-is_front', 'name')
+
     def get_context_data(self, **kwargs):
         '''
         Send some additional data to the template


### PR DESCRIPTION
#### What does this PR do?

Add functionality to reset the cache on deletion of a muscle so that the deleted muscle doesn't appear in the Muscles overview, exercise descriptions, and any muscle relevant descriptions.

#### Description of Task to be completed?

It seems that after deleting a muscle, it keeps appearing in descriptions etc. This is probably due to the cache not being correctly reset.
The cache should be reset after a muscle has been deleted

#### How should this be manually tested?

- Run application.
- Navigate to Excercises > Muscles
- Delete any Muscle
- Navigate to Exercises > Muscles Overview
- Deleted Muscle shouldn't appear here

#### Any background context you want to provide?

None

#### What are the relevant pivotal tracker stories?

Exercise cache when deleting muscles. ID: #154240253
