### PR TITLE
#154240267 Get exercises on mouse over pody part

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -28,6 +28,14 @@ $(document).ready(function() {
             window.location.href = '/exercise/' + suggestion.data.id + '/view/'
         }
     });
+    (function ($) {
+        $(function () {
+            $(document).off('click.bs.tab.data-api', '[data-hover="tab"]');
+            $(document).on('mouseenter.bs.tab.data-api', '[data-toggle="tab"], [data-hover="tab"]', function () {
+                $(this).tab('show');
+            });
+        });
+    })(jQuery);
 });
 </script>
 {% endblock %}
@@ -40,7 +48,7 @@ $(document).ready(function() {
 
 {% cache cache_timeout exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
-<ul class="nav nav-tabs">
+<ul class="nav nav-pills" style="margin-bottom:20px">
     {% for item in exercise_list %}
     <li {% if forloop.first %}class="active"{% endif %}>
         <a href="#tab-{{ item.grouper.id }}" id="category-{{ item.grouper.id }}" data-toggle="tab">{% trans item.grouper.name %}</a>


### PR DESCRIPTION
**What does this PR do?**

A user gets all the exercises associated with a body part once a hover event to happens to that body part

**Description of Task to be completed?**

In this task, I changed from using tabs to pills so that I could enhance UX in interaction with exercise. Now a user just hovers instead of switching between tabs

**How should this be manually tested?**

- Ensure you are loggen in at Wger.
- Browse to the navigation bar and under `Exercises` choose `Exercises ` again
- By hovering over different body parts you will be able to see the exercises

**What are the relevant pivotal tracker stories?**

#154240267 Enable getting exercises for a body part when the mouse hovers over the body part

**Screenshots**

<img width="802" alt="screen shot 2018-02-08 at 10 19 55" src="https://user-images.githubusercontent.com/19430799/35960152-ac15ff7a-0cb9-11e8-96a9-293c482e541f.png">



