### PR TITLE
#154240254 Make translations of exercises and ingredients easier 

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -8,7 +8,23 @@
 <!--
         Title
 -->
-{% block title %}{% trans "Exercises" %}{% endblock %}
+{% block title %}
+{% trans "Exercises" %}<br /><br />
+{% trans "Filter exercises using language:" %}
+<div class="btn-group">
+    <button type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
+            {% trans "Select language" %}  <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li><a href={% url 'exercise:exercise:overview' %}>None</li>
+        {% for sn, language in languages %}
+        <li><a href={% url 'exercise:exercise:overview' %}?lang={{ sn }}>{{ language }}
+        </li>
+        {% endfor %} 
+    </ul>
+</div>
+    
+{% endblock %}
 
 
 
@@ -38,7 +54,6 @@ $(document).ready(function() {
 -->
 {% block content %}
 
-{% cache cache_timeout exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}
@@ -96,7 +111,6 @@ $(document).ready(function() {
     </div>
     {% endfor %}
 </div>
-{% endcache %}
 
 
 {% endblock %}

--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -54,6 +54,7 @@ $(document).ready(function() {
 -->
 {% block content %}
 
+{% cache 1 exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}
@@ -111,6 +112,7 @@ $(document).ready(function() {
     </div>
     {% endfor %}
 </div>
+{% endcache %}
 
 
 {% endblock %}

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -67,7 +67,6 @@ class ExerciseIndexTestCase(WorkoutManagerTestCase):
         '''
         Tests the exercise overview page
         '''
-
         response = self.client.get(reverse('exercise:exercise:overview'))
 
         # Page exists
@@ -81,7 +80,7 @@ class ExerciseIndexTestCase(WorkoutManagerTestCase):
         self.assertEqual(category_1.id, 2)
         self.assertEqual(category_1.name, "Another category")
 
-        # The order of the categories changed if a user is allowed to 
+        # The order of the categories changed if a user is allowed to
         # view exercise for all languages at first galance.
         category_2 = response.context['exercises'][2].category
         self.assertEqual(category_2.id, 3)

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -81,7 +81,9 @@ class ExerciseIndexTestCase(WorkoutManagerTestCase):
         self.assertEqual(category_1.id, 2)
         self.assertEqual(category_1.name, "Another category")
 
-        category_2 = response.context['exercises'][1].category
+        # The order of the categories changed if a user is allowed to 
+        # view exercise for all languages at first galance.
+        category_2 = response.context['exercises'][2].category
         self.assertEqual(category_2.id, 3)
         self.assertEqual(category_2.name, "Yet another category")
 

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -74,6 +74,7 @@ class ExerciseListView(ListView):
         return Exercise.objects.accepted() \
             .order_by('category__id') \
             .select_related()
+
     def get_context_data(self, **kwargs):
         '''
         Pass additional data to the template

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -26,7 +26,23 @@
     </script>
 {% endblock %}
 
-{% block title %}{% trans "Ingredient overview" %}{% endblock %}
+{% block title %}
+{% trans "Ingredient overview" %}<br /><br />
+{% trans "Filter ingredients using language:" %}
+<div class="btn-group">
+        <button type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
+            {% trans "Select language" %}
+                
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" role="menu">
+            <li><a href={% url 'nutrition:ingredient:list' %}>None</li>
+            {% for sn, language in languages %}
+            <li><a href={% url 'nutrition:ingredient:list' %}?lang={{ sn }}>{{ language }}</li>
+            {% endfor %} 
+        </ul>
+    </div>
+{% endblock %}
 
 
 {% block content %}

--- a/wger/nutrition/views/ingredient.py
+++ b/wger/nutrition/views/ingredient.py
@@ -26,6 +26,7 @@ from django.contrib import messages
 from django.utils.translation import ugettext_lazy, ugettext as _
 from django.views.generic import (DeleteView, CreateView, UpdateView, ListView)
 
+from wger.core.models import Language
 from wger.nutrition.forms import UnitChooserForm
 from wger.nutrition.models import Ingredient
 from wger.utils.generic_views import (WgerFormMixin, WgerDeleteMixin)
@@ -55,10 +56,20 @@ class IngredientListView(ListView):
         (the user can also want to see ingredients in English, in addition to his
         native language, see load_ingredient_languages)
         '''
-        languages = load_ingredient_languages(self.request)
-        return (Ingredient.objects.filter(language__in=languages)
-                .filter(status__in=Ingredient.INGREDIENT_STATUS_OK).only(
-                    'id', 'name'))
+
+        query_language = self.request.GET.get('lang', None)
+        language = None
+        if query_language:
+            ln = Language.objects.filter(short_name=query_language)
+            if ln.exists():
+                language = ln.first().id
+        if language:
+            return (Ingredient.objects.filter(language=language)
+                    .filter(status__in=Ingredient.INGREDIENT_STATUS_OK).only(
+                        'id', 'name'))
+        return (Ingredient.objects.filter(
+                        status__in=Ingredient.INGREDIENT_STATUS_OK).only(
+                        'id', 'name'))      
 
     def get_context_data(self, **kwargs):
         '''

--- a/wger/nutrition/views/ingredient.py
+++ b/wger/nutrition/views/ingredient.py
@@ -68,8 +68,8 @@ class IngredientListView(ListView):
                     .filter(status__in=Ingredient.INGREDIENT_STATUS_OK).only(
                         'id', 'name'))
         return (Ingredient.objects.filter(
-                        status__in=Ingredient.INGREDIENT_STATUS_OK).only(
-                        'id', 'name'))      
+                status__in=Ingredient.INGREDIENT_STATUS_OK).only(
+                    'id', 'name'))
 
     def get_context_data(self, **kwargs):
         '''


### PR DESCRIPTION
#### What does the PR do?
*   Make translations of exercises and ingredients easier. A user could only view exercises and ingredients that were created in their current language. This PR is an implementation that enables a user to view all  exercises and ingredients at first. The user can then choose to filter the exercises and ingredients using a language.

#### Description of the tasks to be completed:
* Add a dropdown button for selecting a language
* Add a link to each language in that when a language is selected; a query is passed in the url containing the short name of the language.
* Get the short name of the language from the url.
* Check if it is a valid short name.
* Get the language id of the language whose short name has been passed in the url.
* Filter exercises or ingredients to be displayed using a language by its id.

#### What are the relevant pivotal tracker stories?
* #154240254

#### Screenshots showing outputs:

* Things to note in the screenshots:
     * The url
     * The list of ingredients and exercises 

* Showing the dropdown language list
<img width="702" alt="screen shot 2018-02-08 at 1 25 51 pm" src="https://user-images.githubusercontent.com/19909781/35971021-76643986-0cdd-11e8-8bc4-92e571734aab.png">

* First view of the exercises
<img width="846" alt="screen shot 2018-02-08 at 2 52 40 pm" src="https://user-images.githubusercontent.com/19909781/35971628-c809d870-0cdf-11e8-8774-339e9d45b337.png">
* When a language without exercises is selected
<img width="657" alt="screen shot 2018-02-08 at 1 26 23 pm" src="https://user-images.githubusercontent.com/19909781/35971046-8cd334d8-0cdd-11e8-9925-874ea4ddc8ed.png">

* View of exercises when English language is selected.
<img width="858" alt="screen shot 2018-02-08 at 2 48 01 pm" src="https://user-images.githubusercontent.com/19909781/35971480-25a80098-0cdf-11e8-8e05-dcd796f7a830.png">

* First view of the ingredients
<img width="652" alt="screen shot 2018-02-08 at 1 26 38 pm" src="https://user-images.githubusercontent.com/19909781/35971058-940327d6-0cdd-11e8-9971-94a89b1f49af.png">

* When a language without ingredients is selected.


<img width="648" alt="screen shot 2018-02-08 at 1 27 02 pm" src="https://user-images.githubusercontent.com/19909781/35971251-65be2cda-0cde-11e8-9a6d-fc6efe68e984.png">

* View of ingredients when English language is selected.
<img width="834" alt="screen shot 2018-02-08 at 2 45 10 pm" src="https://user-images.githubusercontent.com/19909781/35971339-b8431966-0cde-11e8-8ba9-93bbf565c1e8.png">




